### PR TITLE
Fix null ref

### DIFF
--- a/save.js
+++ b/save.js
@@ -68,6 +68,10 @@ let save = {
   
 };
 function loadSave(savedData) {
+	if(saveData.carbon == null){
+			resetsaves();
+		}
+		
     carbon = new Decimal(savedData.carbon);
     highestcarbonthisreset = new Decimal(savedData.highestcarbonthisreset);
     productionreduction = new Decimal(savedData.productionreduction);


### PR DESCRIPTION
Null ref to check for blank save on first load.

Specifically errored in ln 71 and 163 of save.js and 592 of main.js

All calling the loadSave function and all nullrefing

Attempted to keep the the existing coding convention.